### PR TITLE
Upgrade bower version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "bower": "~1.2.8"
+    "bower": "~1.3.12"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.1.1",


### PR DESCRIPTION
bower has been upgraded to 1.3 and a bug comes up when running bower-install when no bower_components folder exists
